### PR TITLE
fix the error with mailing

### DIFF
--- a/client/src/Components/Pages/Chat/index.jsx
+++ b/client/src/Components/Pages/Chat/index.jsx
@@ -55,7 +55,7 @@ class Chat extends Component {
       if (data.needImmediateSupport) {
         swal({
           title: `Hey ${this.props.name}`,
-          text: `I think maybe you need to take to the psychological counselling in your school.`,
+          text: `I think maybe you need to talke to the psychological counselling in your school.`,
           icon: "info",
           button: {
             text: "Yes sure!"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
       "!**/bot/index.js",
       "!**/passport.js",
       "!**/db_connection.js",
-      "!**/generalFulfillment.js"
+      "!**/generalFulfillment.js",
+      "!**/dialogflowSessionClient.js",
+      "!**/pusherSessionClient.js"
     ]
   },
   "scripts": {

--- a/server/__test__/api/bot.startChat.js
+++ b/server/__test__/api/bot.startChat.js
@@ -5,7 +5,19 @@ const app = require("./../../app");
 describe("Tesing for bot - startChat - API", () => {
   test("Test route with valid data", (done) => {
     const data = { event: "event" };
+    const loginData = {
+      username: "nadia-2009",
+      password: "123456",
+    }
     request(app)
+      .post("/api/user/login")
+      .send(loginData)
+      .expect("Content-Type", /json/)
+      .expect(200)
+      .end((err, res) => {
+        const token = res.headers["set-cookie"][0].split(";")[0];
+
+        request(app)
       .post("/api/bot/startchat")
       .send(data)
       .expect("Content-Type", /json/)
@@ -14,6 +26,9 @@ describe("Tesing for bot - startChat - API", () => {
         expect(res).toBeDefined();
         done();
       });
+
+
+      })
   });
   test("Test with no data", (done) => {
     request(app)

--- a/server/__test__/bot/support_keywords.js
+++ b/server/__test__/bot/support_keywords.js
@@ -1,0 +1,21 @@
+const supportKeywords = require("./../../router/bot/support_keywords");
+const User = require("./../../database/models/User");
+
+describe("Testing the supportKeywords function", () => {
+  test("test supportKeywords", async () => {
+    User.findOne().then((user) => {
+      const userMessage = "Hi";
+      supportKeywords(userMessage, user.id).then((needSupport) => {
+        expect(needSupport).toBeFalsy();
+      });
+    });
+  });
+  test("test supportKeywords", async () => {
+    User.findOne().then((user) => {
+      const userMessage = "I feel depressed";
+      supportKeywords(userMessage, user.id).then((needSupport) => {
+        expect(needSupport).toBeTruthy();
+      });
+    });
+  });
+});

--- a/server/__test__/database/queries/decideFlow.js
+++ b/server/__test__/database/queries/decideFlow.js
@@ -1,0 +1,29 @@
+const decideFlow = require("./../../../database/queries/decideFlow")
+const buildDB = require("./../../../database/dummy_data/index");
+
+describe("Tesing for decideFlow query", () => {
+  beforeAll(async () => {
+    // build dummy data
+    await buildDB();
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+  });
+
+  beforeEach(async () => {
+    // build dummy data
+    await buildDB();
+  });
+
+  test("Function returns a string", (done) => {
+
+    const result = decideFlow("event")
+    expect(result).toBeDefined();
+    expect(typeof result).toBe("string")
+    done();
+
+  });
+
+
+});

--- a/server/router/bot/dialogflowSessionClient.js
+++ b/server/router/bot/dialogflowSessionClient.js
@@ -44,13 +44,13 @@ module.exports = (query, userId) => new Promise((resolve, reject) => {
 
   // check if the user has sent a message - if so then set this up in the request otherwise,
   // it'll be an event query to start a conversation
-  if (query) {
+  if (query.message) {
     console.log("MESSAGE REACHED!");
     request = {
       session: sessionPath,
       queryInput: {
         text: {
-          text: query,
+          text: query.message,
           languageCode,
         },
       },
@@ -60,7 +60,7 @@ module.exports = (query, userId) => new Promise((resolve, reject) => {
         },
       },
     };
-  } else {
+  } else if (query.event) {
     // decide which event should be sent in the query
     const event = decideFlow(query.event);
     request = {

--- a/server/router/bot/messages.js
+++ b/server/router/bot/messages.js
@@ -16,7 +16,7 @@ module.exports = async (req, res) => {
 
 
   // create responses object
-  await dialogflowResponse(req.body.message, id)
+  await dialogflowResponse(req.body, id)
     .then((responses) => {
       // grab the important stuff
       const result = responses[0].queryResult;

--- a/server/router/bot/startChat.js
+++ b/server/router/bot/startChat.js
@@ -8,7 +8,7 @@ const storeMessages = require("./storeMessages");
 
 module.exports = async (req, res) => {
   const { id } = req.user;
-  await dialogflowResponse(req.body)
+  await dialogflowResponse(req.body, id)
     .then((responses) => {
       // grab the important stuff
 

--- a/server/router/bot/support_keywords.js
+++ b/server/router/bot/support_keywords.js
@@ -40,10 +40,12 @@ module.exports = (userMessage, userId) => new Promise((resolve, reject) => {
             },
           );
 
+          const receptors = process.env.NODE_ENV === "test" ? process.env.STAFF : process.env.STAFF_TEST;
+
           // Message object
           const message = {
             // Comma separated list of recipients
-            to: process.env.STAFF,
+            to: receptors,
 
             // Subject of the message
             subject: "Support needed",

--- a/server/router/bot/support_keywords.js
+++ b/server/router/bot/support_keywords.js
@@ -12,6 +12,11 @@ module.exports = (userMessage, userId) => new Promise((resolve, reject) => {
       // get the conversation that which help detected
       return getThreatConversation(userId)
         .then((result) => {
+          // if no results that mens no need for support
+          if (result.length === 0) {
+            return resolve(false);
+          }
+
           const { userInfo, messages } = result[0];
 
           // build the email body


### PR DESCRIPTION
Relates #32 
check the incoming results from `checkSupprtkeyword` to solve the error.
also, re-order the function so it will store the messages then check for support keywords so the last message that detected will be included in the email.
fix typo in client side message