### PR TITLE
Hide message box for quickreplies and cards 

### DIFF
--- a/client/src/Components/Pages/Chat/index.jsx
+++ b/client/src/Components/Pages/Chat/index.jsx
@@ -78,7 +78,6 @@ class Chat extends Component {
           botMsg.quickReply = e.quickReplies.quickReplies;
           botMsg.text = "";
         } else if (e.message === "card") {
-          console.log("CARD REACHED");
           botMsg.cardReply = e.card;
           botMsg.text = "";
         } else {
@@ -192,6 +191,17 @@ class Chat extends Component {
 
   // RENDER -------------------------------------------------------------------------------------------------------------------------------
   render() {
+    const { botQuickReply, botCardReply } = this.state
+
+    // function that checks if it's a quick reply or card reply
+    // to decide if we should hide the message box
+    const checkReply = (botQuickReply, botCardReply) => {
+      // check if it's a 
+      if (botQuickReply.length > 0 && !botQuickReply.includes("Finished")) return true;
+      if (botCardReply) return true
+      else return false
+    }
+
     // function that renders text by human or bot (ai) (defined as className) as speech bubble
     const ChatBubble = (text, i, className) => {
       return (
@@ -257,7 +267,7 @@ class Chat extends Component {
       <div>
         <ChatWindow>
           <ConversationView>{chat}</ConversationView>
-          <MessageBox>
+          <MessageBox hide={checkReply(botQuickReply, botCardReply)}>
             <Form onSubmit={this.handleSubmit}>
               <input
                 value={this.state.userMessage}

--- a/client/src/Components/Pages/Chat/index.style.js
+++ b/client/src/Components/Pages/Chat/index.style.js
@@ -13,6 +13,7 @@ export const ConversationView = styled.div`
 export const MessageBox = styled.div`
   width: 100%;
   padding: 20px 20px;
+  display: ${props => props.hide ? "none" : "block"};
 `;
 
 export const Form = styled.form`

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,17 +14,4 @@ coverage:
         only_pulls: false
         flags: null
         paths: null
-    patch:
-      default:
-        # basic
-        target: auto
-        threshold: 20%
-        base: auto
-        # advanced
-        branches: null
-        if_no_uploads: error
-        if_not_found: success
-        if_ci_failed: error
-        only_pulls: false
-        flags: null
-        paths: null
+    patch: off


### PR DESCRIPTION
relates issue #107 

We run a reply to check each message and return true if it's a quick reply or card. The only exception is the 'Finished' button where we want them to still be able to write. 